### PR TITLE
Update create index. Add checks to the create index.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8"]  # "3.9", "3.10", "3.11"
-        mongodb-version: ['4.2']  # '4.4', '5.0', '6.0'
+        mongodb-version: ["4.2", "4.4"]  # '5.0', '6.0'
 
     env:
       TEST_MONGO_URL: mongodb://localhost/test

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.pyc
 dist/*
 .coverage
+tmp/*
 
 TODO.md

--- a/README.md
+++ b/README.md
@@ -115,6 +115,38 @@ await init_collection()
 if you want to set the 'expireAfterSeconds' only from method 'update_expiration_value', set it to '-1'.
 if you want skip the index changed, call method 'expiration_index_skip' before init_collection.
 
+### Indexes in replica set cluster
+
+The replica set cluster has a specific behavior when creating indexes.
+If one of the nodes in the cluster is not reachable, the index creation will wait for the node to become available.
+See [Index Builds in Replicated Environments](https://www.mongodb.com/docs/manual/core/index-creation/#index-builds-in-replicated-environments).
+Change this behavior by setting the 'commit_quorum' option to 'majority'. See [createIndexes](https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/#std-label-createIndex-method-commitQuorum).
+
+Example:
+
+```python
+# import
+
+# Initilize DB before calls db methods
+AMPODatabase(url="mongodb://test")
+
+# Pydantic Model
+class ModelA(CollectionWorker):
+    field1: str
+
+    model_config = ORMConfig(
+        orm_collection="test",
+        orm_indexes=[
+            {
+                "keys": ["field1"],
+                "commit_quorum": "majority",
+            }
+        ]
+    )
+
+await init_collection()
+```
+
 ## Relationships between documents
 
 ### Embeded

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Features:
 - Asynchronous
+- Support MongoDB from 4.2
 
 # Usage
 
@@ -121,6 +122,8 @@ The replica set cluster has a specific behavior when creating indexes.
 If one of the nodes in the cluster is not reachable, the index creation will wait for the node to become available.
 See [Index Builds in Replicated Environments](https://www.mongodb.com/docs/manual/core/index-creation/#index-builds-in-replicated-environments).
 Change this behavior by setting the 'commit_quorum' option to 'majority'. See [createIndexes](https://www.mongodb.com/docs/manual/reference/method/db.collection.createIndex/#std-label-createIndex-method-commitQuorum).
+
+Supported only from MongoDB version 4.4.
 
 Example:
 

--- a/ampo/utils.py
+++ b/ampo/utils.py
@@ -31,13 +31,15 @@ class ORMIndex(BaseModel):
     keys: List[str]
     options: Optional[ORMIndexOptions] = None
     skip_initialization: bool = False
-    commit_quorum: Union[commitQuorum, int] = commitQuorum.VOTING_MEMBERS
+    commit_quorum: Optional[Union[commitQuorum, int]] = None
 
     @property
-    def commit_quorum_value(self) -> Union[int, str]:
+    def commit_quorum_value(self) -> Optional[Union[int, str]]:
         """
         Return value of commit quorum
         """
+        if self.commit_quorum is None:
+            return
         if isinstance(self.commit_quorum, int):
             return self.commit_quorum
         return self.commit_quorum.value

--- a/ampo/worker.py
+++ b/ampo/worker.py
@@ -5,6 +5,7 @@ import bson.son
 from bson import ObjectId
 from motor import motor_asyncio
 from pydantic import BaseModel
+from pymongo import IndexModel
 
 from .db import AMPODatabase
 from .utils import (
@@ -15,6 +16,7 @@ from .utils import (
     cfg_orm_bson_codec_options,
     cfg_orm_lock_record,
     datetime_utcnow_tz,
+    period_check_future,
 )
 from .log import logger
 
@@ -280,8 +282,17 @@ async def init_collection():
             if index_is_ttl and orm_index.options.expireAfterSeconds == -1:
                 continue
 
-            await collection.create_index(
-                orm_index.keys,
-                name=index_name,
-                **options
+            # Create index
+            await period_check_future(
+                aws=collection.create_indexes(
+                    [IndexModel(
+                        keys=orm_index.keys,
+                        name=index_name,
+                        **options,
+                    )],
+                    commitQuorum=orm_index.commit_quorum_value
+                ),
+                period=40.0,
+                msg=f"The index '{index_name}' is creating...",
+                logger=logger,
             )

--- a/ampo/worker.py
+++ b/ampo/worker.py
@@ -283,6 +283,9 @@ async def init_collection():
                 continue
 
             # Create index
+            cr_ind_opt: dict = {}
+            if orm_index.commit_quorum_value is not None:
+                cr_ind_opt["commitQuorum"] = orm_index.commit_quorum_value
             await period_check_future(
                 aws=collection.create_indexes(
                     [IndexModel(
@@ -290,7 +293,7 @@ async def init_collection():
                         name=index_name,
                         **options,
                     )],
-                    commitQuorum=orm_index.commit_quorum_value
+                    **cr_ind_opt,
                 ),
                 period=40.0,
                 msg=f"The index '{index_name}' is creating...",

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ Types of changes: Added, Changed, Deprecated, Removed, Fixed, Security
 
 ## [Unreleased]
 
+- Added to index new option - 'commit_quorum'. See [docs](https://www.mongodb.com/docs/manual/reference/command/createIndexes/#std-label-createIndexes-cmd-commitQuorum).
+- Added periodic checking to the method create indexes.
+
+
 ## [0.2.7] - 2024-07-10
 
 ### Added

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,11 @@
 import os
-import asyncio
 import unittest
 import datetime
 from typing import Optional
 
 from bson import ObjectId
 from bson.codec_options import CodecOptions
-from pydantic import ConfigDict, BaseModel
+from pydantic import BaseModel
 
 from ampo import AMPODatabase, CollectionWorker, ORMConfig, init_collection
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import asyncio
+import unittest
+from unittest.mock import MagicMock
+
+from ampo.utils import period_check_future
+
+
+class Utils(unittest.IsolatedAsyncioTestCase):
+
+    async def test_period_check_future(self):
+        """
+        Base usage
+        """
+        async def check(ft: asyncio.Future):
+            await asyncio.sleep(0.1)
+            ft.set_result(True)
+        logger = MagicMock()
+        ft = asyncio.Future()
+
+        # Process
+        asyncio.create_task(check(ft))
+        await period_check_future(
+            aws=ft,
+            logger=logger,
+            msg="test",
+            period=0.06,
+        )
+        self.assertEqual(logger.info.call_count, 1)
+
+        # Check default value
+        ft = asyncio.Future()
+        asyncio.create_task(check(ft))
+        await period_check_future(aws=ft)


### PR DESCRIPTION
- Added to index new option - 'commit_quorum'. See [docs](https://www.mongodb.com/docs/manual/reference/command/createIndexes/#std-label-createIndexes-cmd-commitQuorum).
- Added periodic checking to the method create indexes.